### PR TITLE
feat(device): gains BaseLoad device for power demand simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,155 @@
 version = 4
 
 [[package]]
+name = "cfg-if"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
 name = "vpp-sim"
 version = "0.1.0"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+rand = "0.9.2"

--- a/README.md
+++ b/README.md
@@ -20,18 +20,33 @@ The simulation advances in fast-forwarded, discrete time steps (e.g. 5-minute in
 
 Stay tuned!
 
+## Usage
+
+Running the default binary will trigger a 20-step simulation with a simple baseload model. This will output the modeled baseload demand (in kW) at each time step:
+
+```bash
+cargo run --release
+```
+
+### Expected outputs:
+```
+t=0, baseload_kw=1.35
+t=1, baseload_kw=1.39
+t=2, baseload_kw=1.46
+t=3, baseload_kw=1.48
+...
+t=19, baseload_kw=1.22
+```
+
+
+
 ## ⏱️ Running the simulation clock
 
 The simulation clock drives the virtual power plant model by advancing in fixed time steps. It can be run using the `Clock` struct, which provides methods to advance time step-by-step or run a function at each time step until completion.
 
 ### Example
 
-You can run the simple clock demo with: 
-``` bash
-cargo run
-```
-
-or include the `Clock` in your own project as follows:
+You can run the simple `Clock` with:
 
 ```rust
 use vpp_sim::sim::clock::Clock;
@@ -40,16 +55,27 @@ let mut clock = Clock::new(5);
 clock.run(|t| println!("Step {}", t));
 ```
 
-### Expected Outputs
+## ⚡ Running the BaseLoad model
 
-For a clock configured with 5 total steps, the output will be:
+The `BaseLoad` model simulates the baseline electricity consumption of a household. It can be run using the `BaseLoad` struct, which provides methods to get the load at each time step.
 
-```
-Step 0
-Step 1
-Step 2
-Step 3
-Step 4
+You can run the simple `BaseLoad` with:
+
+```rust
+use vpp_sim::sim::load::BaseLoad;
+
+// Create a baseload with typical parameters
+let mut load = BaseLoad::new(
+    1.0,   // base_kw - average consumption
+    0.5,   // amp_kw - daily variation
+    0.0,   // phase_rad - no phase shift (minimum at midnight)
+    0.05,  // noise_std - small random variation
+    24,    // steps_per_day - hourly resolution
+    42,    // seed - for reproducible randomness
+);
+
+// Get demand at specific time step
+let demand = load.demand_kw(12); // demand at noon
 ```
 
 ## License

--- a/src/devices/baseload.rs
+++ b/src/devices/baseload.rs
@@ -1,16 +1,64 @@
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
+/// A baseload generator that models daily electricity consumption patterns.
+///
+/// `BaseLoad` creates a sinusoidal power demand pattern with configurable baseline,
+/// amplitude, phase, and random noise to simulate typical daily load patterns.
+///
+/// # Examples
+///
+/// ```
+/// use vpp_sim::devices::baseload::BaseLoad;
+///
+/// // Create a baseload with typical parameters
+/// let mut load = BaseLoad::new(
+///     1.0,   // base_kw - average consumption
+///     0.5,   // amp_kw - daily variation
+///     0.0,   // phase_rad - no phase shift (minimum at midnight)
+///     0.05,  // noise_std - small random variation
+///     24,    // steps_per_day - hourly resolution
+///     42,    // seed - for reproducible randomness
+/// );
+///
+/// // Get demand at noon
+/// let demand = load.demand_kw(12);
+/// ```
 #[derive(Debug, Clone)]
 pub struct BaseLoad {
+    /// Baseline power consumption in kilowatts
     pub base_kw: f32,
+
+    /// Amplitude of the sinusoidal variation in kilowatts
     pub amp_kw: f32,
+
+    /// Phase offset of the sinusoidal pattern in radians
     pub phase_rad: f32,
+
+    /// Standard deviation of the Gaussian noise in kilowatts
     pub noise_std: f32,
+
+    /// Number of time steps per simulated day
     pub steps_per_day: usize,
+
+    /// Random number generator for noise generation
     rng: StdRng,
 }
 
 impl BaseLoad {
+    /// Creates a new baseload generator with the specified parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_kw` - The baseline power consumption in kilowatts
+    /// * `amp_kw` - The amplitude of sinusoidal daily variation in kilowatts
+    /// * `phase_rad` - The phase offset in radians (0 = minimum at start of day)
+    /// * `noise_std` - The standard deviation of Gaussian noise in kilowatts
+    /// * `steps_per_day` - The number of time steps per simulated day
+    /// * `seed` - Random seed for reproducible noise generation
+    ///
+    /// # Returns
+    ///
+    /// A new `BaseLoad` instance configured with the specified parameters
     pub fn new(
         base_kw: f32,
         amp_kw: f32,
@@ -29,7 +77,22 @@ impl BaseLoad {
         }
     }
 
-    /// Deterministic + noisy kW demand at a timestep
+    /// Calculates the power demand at a specific time step.
+    ///
+    /// This method computes the power demand as a combination of:
+    /// - A baseline component (`base_kw`)
+    /// - A sinusoidal daily pattern with specified amplitude and phase
+    /// - Random Gaussian noise with specified standard deviation
+    ///
+    /// The demand is guaranteed to be non-negative.
+    ///
+    /// # Arguments
+    ///
+    /// * `timestep` - The simulation time step
+    ///
+    /// # Returns
+    ///
+    /// The power demand in kilowatts at the specified time step
     pub fn demand_kw(&mut self, timestep: usize) -> f32 {
         let day_pos = (timestep % self.steps_per_day) as f32 / self.steps_per_day as f32; // [0,1)
         let angle = 2.0 * std::f32::consts::PI * day_pos + self.phase_rad;

--- a/src/devices/baseload.rs
+++ b/src/devices/baseload.rs
@@ -1,0 +1,51 @@
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+#[derive(Debug, Clone)]
+pub struct BaseLoad {
+    pub base_kw: f32,
+    pub amp_kw: f32,
+    pub phase_rad: f32,
+    pub noise_std: f32,
+    pub steps_per_day: usize,
+    rng: StdRng,
+}
+
+impl BaseLoad {
+    pub fn new(
+        base_kw: f32,
+        amp_kw: f32,
+        phase_rad: f32,
+        noise_std: f32,
+        steps_per_day: usize,
+        seed: u64,
+    ) -> Self {
+        Self {
+            base_kw,
+            amp_kw,
+            phase_rad,
+            noise_std,
+            steps_per_day: steps_per_day.max(1),
+            rng: StdRng::seed_from_u64(seed),
+        }
+    }
+
+    /// Deterministic + noisy kW demand at a timestep
+    pub fn demand_kw(&mut self, timestep: usize) -> f32 {
+        let day_pos = (timestep % self.steps_per_day) as f32 / self.steps_per_day as f32; // [0,1)
+        let angle = 2.0 * std::f32::consts::PI * day_pos + self.phase_rad;
+        let sinus = angle.sin();
+
+        let noise = if self.noise_std > 0.0 {
+            // simple Gaussian-ish noise via Box-Muller
+            let u1: f32 = self.rng.random::<f32>().clamp(1e-6, 1.0);
+            let u2: f32 = self.rng.random::<f32>();
+            let z0 = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos();
+            z0 * self.noise_std
+        } else {
+            0.0
+        };
+
+        let kw = self.base_kw + self.amp_kw * sinus + noise;
+        kw.max(0.0) // no negative demand
+    }
+}

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,0 +1,1 @@
+pub mod baseload;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,25 @@
-mod sim;
-use sim::clock::Clock;
+mod devices {
+    pub mod baseload;
+}
+
+mod sim {
+    pub mod clock;
+}
+
 fn main() {
-    let mut clock = Clock::new(5);
-    clock.run(|t| println!("Step {}", t));
+    let mut clock = sim::clock::Clock::new(20);
+    let mut load = devices::baseload::BaseLoad::new(
+        0.8,  /* base_kw */
+        0.7,  /* amp_kw */
+        1.2,  /* phase_rad */
+        0.05, /* noise_std */
+        96,   /* steps_per_day */
+        42,   /* seed */
+    );
+
+    clock.run(|t| {
+        let kw = load.demand_kw(t);
+        println!("t={t}, baseload_kw={kw:.2}");
+        // later: push `kw` into feeder aggregator
+    })
 }


### PR DESCRIPTION
This PR adds the first load device to the system, enabling aggregation and feeder simulations in future features.

The device is a `BaseLoad` component to simulate household electricity demand patterns in the VPP simulator.

Details:
- Models daily load using a sinusoidal function with Gaussian noise via the [Box–Muller transform](https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform).
- Parameters:
  - base load
  - amplitude
  - phase, noise
  - steps per day.
- RNG is seedable → yields reproducible and deterministic simulations.
- Non-negative kW demand values are guaranteed. 
- Time resolution is flexible; timesteps wrap cleanly for multi-day runs.
- Logs device demand each tick when driven by the simulation clock.

Closes #4