### PR TITLE
feat(solar): gains SolarPv device for photovoltaic generation simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ let mut pv = SolarPv::new(
     0.05,  // noise_std - small random variation for cloud cover
     42,    // seed - for reproducible randomness
 );
-// Get generation at specific time step based on daylight fraction
-let generation = pv.gen_kw(0.5); // 50% daylight fraction
+// Get generation at specific time step (e.g., at noon)
+let generation = pv.gen_kw(12); // generation at timestep 12 (noon)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The `SolarPV` model simulates the electricity generation from a residential sola
 You can run the simple `SolarPV` with:
 
 ```rust
-use vpp_sim::sim::solar::SolarPV;
+use vpp_sim::devices::solar::SolarPv;
 // Create a solar PV system with a specified capacity
 let mut pv = SolarPv::new(
     5.0,   // kw_peak - maximum output in ideal conditions

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The **Virtual Power Plant Simulator** is an open source project aiming to simula
 
 The simulator models a local distribution feeder with a mix of flexible and inflexible devices, including:
 
-- 🏠 Residential solar PV
+- ☀️ Residential solar PV
 - 🔋 Home battery storage systems
 - 🚗 EV charging stations
 - 💡 Flexible and baseline household demand
@@ -21,30 +21,30 @@ The simulation advances in fast-forwarded, discrete time steps (e.g. 5-minute in
 Stay tuned!
 
 ## Usage
+### 🧩 Running the demo simulation
 
-Running the default binary will trigger a 20-step simulation with a simple baseload model. This will output the modeled baseload demand (in kW) at each time step:
+Running the default binary will trigger a demonstrative 96-step simulation (15-minute interval) with a simple baseload model. This will output the modeled baseload demand (in kW) at each time step:
 
 ```bash
 cargo run --release
 ```
 
-### Expected outputs:
+#### Expected outputs:
 ```
-t=0, baseload_kw=1.35
-t=1, baseload_kw=1.39
-t=2, baseload_kw=1.46
-t=3, baseload_kw=1.48
+t=0, baseload_kw=1.35, solar_kw=0.00, net_kw=1.35
+t=1, baseload_kw=1.39, solar_kw=0.00, net_kw=1.39
+t=2, baseload_kw=1.46, solar_kw=0.00, net_kw=1.46
+t=3, baseload_kw=1.48, solar_kw=0.00, net_kw=1.48
 ...
-t=19, baseload_kw=1.22
+t=48, baseload_kw=0.18, solar_kw=5.31, net_kw=-5.13 # peak solar generation at noon
+...
+t=95, baseload_kw=1.39, solar_kw=0.00, net_kw=1.39
 ```
 
 
-
-## ⏱️ Running the simulation clock
+### ⏱️ Running the simulation clock
 
 The simulation clock drives the virtual power plant model by advancing in fixed time steps. It can be run using the `Clock` struct, which provides methods to advance time step-by-step or run a function at each time step until completion.
-
-### Example
 
 You can run the simple `Clock` with:
 
@@ -55,7 +55,7 @@ let mut clock = Clock::new(5);
 clock.run(|t| println!("Step {}", t));
 ```
 
-## ⚡ Running the BaseLoad model
+### ⚡ Running the BaseLoad model
 
 The `BaseLoad` model simulates the baseline electricity consumption of a household. It can be run using the `BaseLoad` struct, which provides methods to get the load at each time step.
 
@@ -76,6 +76,26 @@ let mut load = BaseLoad::new(
 
 // Get demand at specific time step
 let demand = load.demand_kw(12); // demand at noon
+```
+
+### ☀️ Running the Solar PV model
+The `SolarPV` model simulates the electricity generation from a residential solar photovoltaic system. It can be run using the `SolarPV` struct, which provides methods to get the generation at each time step based on a daylight fraction.
+
+You can run the simple `SolarPV` with:
+
+```rust
+use vpp_sim::sim::solar::SolarPV;
+// Create a solar PV system with a specified capacity
+let mut pv = SolarPv::new(
+    5.0,   // kw_peak - maximum output in ideal conditions
+    24,    // steps_per_day - hourly resolution
+    6,     // sunrise_idx - 6am sunrise
+    18,    // sunset_idx - 6pm sunset
+    0.05,  // noise_std - small random variation for cloud cover
+    42,    // seed - for reproducible randomness
+);
+// Get generation at specific time step based on daylight fraction
+let generation = pv.gen_kw(0.5); // 50% daylight fraction
 ```
 
 ## License

--- a/src/devices/solar.rs
+++ b/src/devices/solar.rs
@@ -1,0 +1,60 @@
+use rand::{Rng, SeedableRng, rngs::StdRng};
+
+#[derive(Debug, Clone)]
+pub struct SolarPv {
+    pub kw_peak: f32,
+    pub steps_per_day: usize,
+    pub sunrise_idx: usize, // inclusive
+    pub sunset_idx: usize,  // exclusive
+    pub noise_std: f32,     // e.g. 0.05 for +/-5% (Gaussian-ish)
+    rng: StdRng,
+}
+
+impl SolarPv {
+    pub fn new(
+        kw_peak: f32,
+        steps_per_day: usize,
+        sunrise_idx: usize,
+        sunset_idx: usize,
+        noise_std: f32,
+        seed: u64,
+    ) -> Self {
+        assert!(steps_per_day > 0);
+        assert!(sunrise_idx < sunset_idx && sunset_idx <= steps_per_day);
+        Self {
+            kw_peak: kw_peak.max(0.0),
+            steps_per_day,
+            sunrise_idx,
+            sunset_idx,
+            noise_std: noise_std.max(0.0),
+            rng: StdRng::seed_from_u64(seed),
+        }
+    }
+
+    fn daylight_frac(&self, t: usize) -> f32 {
+        let day_t = t % self.steps_per_day;
+        if day_t < self.sunrise_idx || day_t >= self.sunset_idx {
+            return 0.0;
+        }
+        let span = (self.sunset_idx - self.sunrise_idx) as f32;
+        let x = (day_t - self.sunrise_idx) as f32 / span; // [0,1)
+        // Half-cosine dome: 0 -> 1 -> 0 across daylight
+        0.5 * (1.0 - (std::f32::consts::PI * x).cos())
+    }
+
+    pub fn gen_kw(&mut self, timestep: usize) -> f32 {
+        let frac = self.daylight_frac(timestep);
+        if frac <= 0.0 {
+            return 0.0;
+        }
+
+        // Gaussian-ish noise via Box–Muller
+        let (mut u1, u2): (f32, f32) = (Rng::random(&mut self.rng), Rng::random(&mut self.rng));
+        u1 = u1.clamp(1e-6, 1.0);
+        let z0 = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos(); // ~N(0,1)
+        let mult = 1.0 + z0 * self.noise_std;
+
+        let kw = self.kw_peak * frac * mult;
+        kw.max(0.0)
+    }
+}

--- a/src/devices/solar.rs
+++ b/src/devices/solar.rs
@@ -1,16 +1,72 @@
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
+/// A solar PV generator that models power generation based on daylight hours.
+///
+/// `SolarPv` creates a half-cosine shaped generation profile between sunrise and sunset
+/// times with configurable peak power output and random noise to simulate
+/// variations due to weather conditions.
+///
+/// # Examples
+///
+/// ```
+/// use vpp_sim::devices::solar::SolarPv;
+///
+/// // Create a solar PV system (5kW peak, 24 steps per day, sunrise at 6am, sunset at 6pm)
+/// let mut pv = SolarPv::new(
+///     5.0,   // kw_peak - maximum output in ideal conditions
+///     24,    // steps_per_day - hourly resolution
+///     6,     // sunrise_idx - 6am sunrise
+///     18,    // sunset_idx - 6pm sunset
+///     0.05,  // noise_std - small random variation for cloud cover
+///     42,    // seed - for reproducible randomness
+/// );
+///
+/// // Get generation at noon (step 12)
+/// let generation = pv.gen_kw(12);
+/// ```
 #[derive(Debug, Clone)]
 pub struct SolarPv {
+    /// Maximum power output in kilowatts under ideal conditions
     pub kw_peak: f32,
+
+    /// Number of time steps per simulated day
     pub steps_per_day: usize,
+
+    /// Time step index when sunrise occurs (inclusive)
     pub sunrise_idx: usize, // inclusive
-    pub sunset_idx: usize,  // exclusive
-    pub noise_std: f32,     // e.g. 0.05 for +/-5% (Gaussian-ish)
+
+    /// Time step index when sunset occurs (exclusive)
+    pub sunset_idx: usize, // exclusive
+
+    /// Standard deviation of the Gaussian noise as a fraction of output
+    pub noise_std: f32, // e.g. 0.05 for +/-5% (Gaussian-ish)
+
+    /// Random number generator for noise generation
     rng: StdRng,
 }
 
 impl SolarPv {
+    /// Creates a new solar PV generator with the specified parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `kw_peak` - Maximum power output in kilowatts under ideal conditions
+    /// * `steps_per_day` - Number of time steps per simulated day
+    /// * `sunrise_idx` - Time step index when sunrise occurs (inclusive)
+    /// * `sunset_idx` - Time step index when sunset occurs (exclusive)
+    /// * `noise_std` - Standard deviation of noise (e.g., 0.05 for ±5% variation)
+    /// * `seed` - Random seed for reproducible noise generation
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if:
+    /// - `steps_per_day` is zero
+    /// - `sunrise_idx` is greater than `sunset_idx`
+    /// - `sunset_idx` exceeds `steps_per_day`
+    ///
+    /// # Returns
+    ///
+    /// A new `SolarPv` instance configured with the specified parameters
     pub fn new(
         kw_peak: f32,
         steps_per_day: usize,
@@ -31,6 +87,19 @@ impl SolarPv {
         }
     }
 
+    /// Calculates the daylight fraction for a specific time step.
+    ///
+    /// Returns a value between 0.0 and 1.0 representing the relative
+    /// solar intensity, following a half-cosine shape from sunrise to sunset.
+    /// Returns 0.0 during nighttime hours.
+    ///
+    /// # Arguments
+    ///
+    /// * `t` - The simulation time step
+    ///
+    /// # Returns
+    ///
+    /// A fraction between 0.0 and 1.0 representing the relative solar intensity
     fn daylight_frac(&self, t: usize) -> f32 {
         let day_t = t % self.steps_per_day;
         if day_t < self.sunrise_idx || day_t >= self.sunset_idx {
@@ -42,6 +111,21 @@ impl SolarPv {
         0.5 * (1.0 - (std::f32::consts::PI * x).cos())
     }
 
+    /// Calculates the power generation at a specific time step.
+    ///
+    /// This method computes the power generation as a combination of:
+    /// - Base solar output following a half-cosine curve during daylight hours
+    /// - Random Gaussian noise to simulate variations due to cloud cover
+    ///
+    /// The generation is guaranteed to be non-negative.
+    ///
+    /// # Arguments
+    ///
+    /// * `timestep` - The simulation time step
+    ///
+    /// # Returns
+    ///
+    /// The power generation in kilowatts at the specified time step
     pub fn gen_kw(&mut self, timestep: usize) -> f32 {
         let frac = self.daylight_frac(timestep);
         if frac <= 0.0 {

--- a/src/devices/solar.rs
+++ b/src/devices/solar.rs
@@ -108,7 +108,7 @@ impl SolarPv {
         let span = (self.sunset_idx - self.sunrise_idx) as f32;
         let x = (day_t - self.sunrise_idx) as f32 / span; // [0,1)
         // Half-cosine dome: 0 -> 1 -> 0 across daylight
-        0.5 * (1.0 - (std::f32::consts::PI * x).cos())
+        0.5 * (1.0 - (2.0 * std::f32::consts::PI * x).cos())
     }
 
     /// Calculates the power generation at a specific time step.
@@ -140,5 +140,131 @@ impl SolarPv {
 
         let kw = self.kw_peak * frac * mult;
         kw.max(0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_solar_pv() {
+        let pv = SolarPv::new(5.0, 24, 6, 18, 0.05, 42);
+        assert_eq!(pv.kw_peak, 5.0);
+        assert_eq!(pv.steps_per_day, 24);
+        assert_eq!(pv.sunrise_idx, 6);
+        assert_eq!(pv.sunset_idx, 18);
+        assert_eq!(pv.noise_std, 0.05);
+    }
+
+    #[test]
+    fn test_negative_kw_peak_clamped_to_zero() {
+        let pv = SolarPv::new(-1.0, 24, 6, 18, 0.05, 42);
+        assert_eq!(pv.kw_peak, 0.0);
+    }
+
+    #[test]
+    fn test_negative_noise_std_clamped_to_zero() {
+        let pv = SolarPv::new(5.0, 24, 6, 18, -0.05, 42);
+        assert_eq!(pv.noise_std, 0.0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_zero_steps_per_day_panics() {
+        SolarPv::new(5.0, 0, 0, 1, 0.05, 42);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sunset_before_sunrise_panics() {
+        SolarPv::new(5.0, 24, 18, 6, 0.05, 42);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sunset_exceeds_steps_panics() {
+        SolarPv::new(5.0, 24, 6, 25, 0.05, 42);
+    }
+
+    #[test]
+    fn test_daylight_frac() {
+        let pv = SolarPv::new(5.0, 24, 6, 18, 0.0, 42);
+
+        // Night hours return 0.0
+        assert_eq!(pv.daylight_frac(0), 0.0); // Midnight
+        assert_eq!(pv.daylight_frac(5), 0.0); // 5am
+        assert_eq!(pv.daylight_frac(18), 0.0); // 6pm
+        assert_eq!(pv.daylight_frac(23), 0.0); // 11pm
+
+        // Dawn starts with near-zero
+        let dawn_frac = dbg!(pv.daylight_frac(6));
+        assert!(dawn_frac < 0.1);
+
+        // Noon (12) should be near peak (max value)
+        let noon_frac = pv.daylight_frac(12);
+        assert!(noon_frac > 0.95);
+
+        // Should be symmetric around noon
+        assert!((pv.daylight_frac(9) - pv.daylight_frac(15)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_no_generation_at_night() {
+        let mut pv = SolarPv::new(5.0, 24, 6, 18, 0.0, 42);
+
+        // No generation during night hours
+        assert_eq!(pv.gen_kw(0), 0.0); // Midnight
+        assert_eq!(pv.gen_kw(5), 0.0); // 5am
+        assert_eq!(pv.gen_kw(18), 0.0); // 6pm
+        assert_eq!(pv.gen_kw(23), 0.0); // 11pm
+    }
+
+    #[test]
+    fn test_peak_generation_at_noon() {
+        let mut pv = SolarPv::new(5.0, 24, 6, 18, 0.0, 42);
+
+        // With noise_std = 0, noon should generate close to peak
+        let noon_gen = pv.gen_kw(12);
+        assert!(noon_gen > 4.9 && noon_gen <= 5.0);
+    }
+
+    #[test]
+    fn test_deterministic_with_same_seed() {
+        let mut pv1 = SolarPv::new(5.0, 24, 6, 18, 0.1, 42);
+        let mut pv2 = SolarPv::new(5.0, 24, 6, 18, 0.1, 42);
+
+        // Same seed should produce identical generation
+        for t in 0..24 {
+            assert_eq!(pv1.gen_kw(t), pv2.gen_kw(t));
+        }
+    }
+
+    #[test]
+    fn test_different_seeds_produce_different_results() {
+        let mut pv1 = SolarPv::new(5.0, 24, 6, 18, 0.1, 42);
+        let mut pv2 = SolarPv::new(5.0, 24, 6, 18, 0.1, 43);
+
+        // Different seeds should produce different generation
+        let mut all_same = true;
+        for t in 6..18 {
+            // Check only daylight hours
+            if (pv1.gen_kw(t) - pv2.gen_kw(t)).abs() > 1e-5 {
+                all_same = false;
+                break;
+            }
+        }
+
+        assert!(!all_same);
+    }
+
+    #[test]
+    fn test_multi_day_cycle() {
+        let mut pv = SolarPv::new(5.0, 24, 6, 18, 0.0, 42);
+
+        // Generation should repeat in daily cycles
+        for t in 0..24 {
+            assert_eq!(pv.gen_kw(t), pv.gen_kw(t + 24));
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod devices {
     pub mod baseload;
+    pub mod solar;
 }
 
 mod sim {
@@ -7,19 +8,34 @@ mod sim {
 }
 
 fn main() {
-    let mut clock = sim::clock::Clock::new(20);
+    let steps_per_day = 96; // 15-minute intervals
+    let mut clock = sim::clock::Clock::new(steps_per_day * 2); // Simulate 2 days
+
     let mut load = devices::baseload::BaseLoad::new(
-        0.8,  /* base_kw */
-        0.7,  /* amp_kw */
-        1.2,  /* phase_rad */
-        0.05, /* noise_std */
-        96,   /* steps_per_day */
-        42,   /* seed */
+        0.8,           /* base_kw */
+        0.7,           /* amp_kw */
+        1.2,           /* phase_rad */
+        0.05,          /* noise_std */
+        steps_per_day, /* steps_per_day */
+        42,            /* seed */
+    );
+
+    let mut pv = devices::solar::SolarPv::new(
+        5.0,           /* kw_peak */
+        steps_per_day, /* steps_per_day */
+        24,            /* sunrise_idx (6 AM) */
+        72,            /* sunset_idx (6 PM) */
+        0.05,          /* noise_std */
+        42,            /* seed */
     );
 
     clock.run(|t| {
-        let kw = load.demand_kw(t);
-        println!("t={t}, baseload_kw={kw:.2}");
+        let base_demand_kw = load.demand_kw(t);
+        let solar_kw = pv.gen_kw(t);
+        let net_kw = base_demand_kw - solar_kw;
+        println!(
+            "t={t}, baseload_kw={base_demand_kw:.2}, solar_kw={solar_kw:.2}, net_kw={net_kw:.2}"
+        );
         // later: push `kw` into feeder aggregator
     })
 }


### PR DESCRIPTION
This PR adds a Solar Photovoltaic load device to the system. The device simulates daily solar generation with a configurable half-cosine profile between sunrise and sunset times.

The device is represented by a `SolarPv` struct that simulates residential or commercial solar panel generation with simple daily patterns.

### Details:
- Models solar generation using a half-cosine function between sunrise and sunset with Gaussian noise via [Box–Muller transform](https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform)
- Parameters:
  - peak capacity (kW)
  - sunrise/sunset time indexes
  - noise level
  - steps per day
- RNG is seedable → yields reproducible and deterministic simulations
- Non-negative kW generation values are guaranteed
- Time resolution is flexible; timesteps wrap cleanly for multi-day runs
- Test suite verifies generation patterns, edge cases, and deterministic behavior

Closes #5