### PR TITLE
refactor(device): Refactor device types extract commonalities

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ cargo run --release
 
 #### Expected outputs:
 ```
-t=0, baseload_kw=1.35, solar_kw=0.00, net_kw=1.35
-t=1, baseload_kw=1.39, solar_kw=0.00, net_kw=1.39
-t=2, baseload_kw=1.46, solar_kw=0.00, net_kw=1.46
-t=3, baseload_kw=1.48, solar_kw=0.00, net_kw=1.48
+Timestep 0: BaseLoad demand = 1.353 kW, SolarPV generation = 0.000 kW, Net = 1.353 kW
+Timestep 1: BaseLoad demand = 1.387 kW, SolarPV generation = 0.000 kW, Net = 1.387 kW
+Timestep 2: BaseLoad demand = 1.463 kW, SolarPV generation = 0.000 kW, Net = 1.463 kW
 ...
-t=48, baseload_kw=0.18, solar_kw=5.31, net_kw=-5.13 # peak solar generation at noon
+# peak solar generation at noon
+Timestep 48: BaseLoad demand = 0.183 kW, SolarPV generation = -5.310 kW, Net = -5.127 kW
 ...
-t=95, baseload_kw=1.39, solar_kw=0.00, net_kw=1.39
+Timestep 95: BaseLoad demand = 1.393 kW, SolarPV generation = 0.000 kW, Net = 1.393 kW
 ```
 
 

--- a/src/devices/baseload.rs
+++ b/src/devices/baseload.rs
@@ -1,4 +1,5 @@
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use crate::devices::types::{Device, gaussian_noise};
+use rand::{SeedableRng, rngs::StdRng};
 
 /// A baseload generator that models daily electricity consumption patterns.
 ///
@@ -21,7 +22,7 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 /// );
 ///
 /// // Get demand at noon
-/// let demand = load.demand_kw(12);
+/// let demand = load.power_kw(12);
 /// ```
 #[derive(Debug, Clone)]
 pub struct BaseLoad {
@@ -76,7 +77,9 @@ impl BaseLoad {
             rng: StdRng::seed_from_u64(seed),
         }
     }
+}
 
+impl Device for BaseLoad {
     /// Calculates the power demand at a specific time step.
     ///
     /// This method computes the power demand as a combination of:
@@ -93,23 +96,18 @@ impl BaseLoad {
     /// # Returns
     ///
     /// The power demand in kilowatts at the specified time step
-    pub fn demand_kw(&mut self, timestep: usize) -> f32 {
+    fn power_kw(&mut self, timestep: usize) -> f32 {
         let day_pos = (timestep % self.steps_per_day) as f32 / self.steps_per_day as f32; // [0,1)
         let angle = 2.0 * std::f32::consts::PI * day_pos + self.phase_rad;
         let sinus = angle.sin();
 
-        let noise = if self.noise_std > 0.0 {
-            // simple Gaussian-ish noise via Box-Muller
-            let u1: f32 = self.rng.random::<f32>().clamp(1e-6, 1.0);
-            let u2: f32 = self.rng.random::<f32>();
-            let z0 = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos();
-            z0 * self.noise_std
-        } else {
-            0.0
-        };
-
+        let noise = gaussian_noise(&mut self.rng, self.noise_std);
         let kw = self.base_kw + self.amp_kw * sinus + noise;
         kw.max(0.0) // no negative demand
+    }
+
+    fn device_type(&self) -> &'static str {
+        "BaseLoad"
     }
 }
 
@@ -141,18 +139,18 @@ mod tests {
         let mut load = BaseLoad::new(2.0, 1.0, 0.0, 0.0, 4, 42);
 
         // At phase 0, first step should be base_kw (since sin(0) = 0)
-        assert_eq!(load.demand_kw(0), 2.0);
+        assert_eq!(load.power_kw(0), 2.0);
 
         // At quarter day (π/2), should be base_kw + amp_kw (since sin(π/2) = 1)
-        let demand = load.demand_kw(1);
+        let demand = load.power_kw(1);
         assert!((demand - 3.0).abs() < 1e-5);
 
         // At half day (π), should be base_kw (since sin(π) = 0)
-        let demand = load.demand_kw(2);
+        let demand = load.power_kw(2);
         assert!((demand - 2.0).abs() < 1e-5);
 
         // At 3/4 day (3π/2), should be base_kw - amp_kw (since sin(3π/2) = -1)
-        let demand = load.demand_kw(3);
+        let demand = load.power_kw(3);
         assert!((demand - 1.0).abs() < 1e-5);
     }
 
@@ -162,7 +160,7 @@ mod tests {
         let mut load = BaseLoad::new(2.0, 1.0, PI / 2.0, 0.0, 4, 42);
 
         // At phase π/2, first step should be base_kw + amp_kw (since sin(π/2) = 1)
-        let demand = load.demand_kw(0);
+        let demand = load.power_kw(0);
         assert!((demand - 3.0).abs() < 1e-5);
     }
 
@@ -172,7 +170,7 @@ mod tests {
         let mut load = BaseLoad::new(0.5, 1.0, 0.0, 0.0, 4, 42);
 
         // At 3/4 day (3π/2), base_kw - amp_kw would be negative, but should be clamped to 0
-        let demand = load.demand_kw(3);
+        let demand = load.power_kw(3);
         assert_eq!(demand, 0.0);
     }
 
@@ -183,7 +181,7 @@ mod tests {
         let mut load2 = BaseLoad::new(1.0, 0.0, 0.0, 0.5, 10, 42);
 
         for i in 0..5 {
-            assert_eq!(load1.demand_kw(i), load2.demand_kw(i));
+            assert_eq!(load1.power_kw(i), load2.power_kw(i));
         }
     }
 
@@ -195,7 +193,7 @@ mod tests {
 
         let mut all_same = true;
         for i in 0..5 {
-            if (load1.demand_kw(i) - load2.demand_kw(i)).abs() > 1e-5 {
+            if (load1.power_kw(i) - load2.power_kw(i)).abs() > 1e-5 {
                 all_same = false;
                 break;
             }

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -1,1 +1,10 @@
+//! Device simulation components for power system modeling.
+
 pub mod baseload;
+pub mod solar;
+pub mod types;
+
+// Re-export the main types for convenience
+pub use baseload::BaseLoad;
+pub use solar::SolarPv;
+pub use types::Device;

--- a/src/devices/solar.rs
+++ b/src/devices/solar.rs
@@ -1,4 +1,5 @@
-use rand::{Rng, SeedableRng, rngs::StdRng};
+use crate::devices::types::{Device, gaussian_noise};
+use rand::{SeedableRng, rngs::StdRng};
 
 /// A solar PV generator that models power generation based on daylight hours.
 ///
@@ -22,7 +23,7 @@ use rand::{Rng, SeedableRng, rngs::StdRng};
 /// );
 ///
 /// // Get generation at noon (step 12)
-/// let generation = pv.gen_kw(12);
+/// let generation = pv.power_kw(12);
 /// ```
 #[derive(Debug, Clone)]
 pub struct SolarPv {
@@ -111,6 +112,13 @@ impl SolarPv {
         0.5 * (1.0 - (2.0 * std::f32::consts::PI * x).cos())
     }
 
+    // pub fn power_kw(&mut self, timestep: usize) -> f32 {
+    //     // Return negative for generation (according to power flow convention)
+    //     -self.power_kw(timestep)
+    // }
+}
+
+impl Device for SolarPv {
     /// Calculates the power generation at a specific time step.
     ///
     /// This method computes the power generation as a combination of:
@@ -126,20 +134,21 @@ impl SolarPv {
     /// # Returns
     ///
     /// The power generation in kilowatts at the specified time step
-    pub fn gen_kw(&mut self, timestep: usize) -> f32 {
+    fn power_kw(&mut self, timestep: usize) -> f32 {
         let frac = self.daylight_frac(timestep);
         if frac <= 0.0 {
             return 0.0;
         }
 
-        // Gaussian-ish noise via Box–Muller
-        let (mut u1, u2): (f32, f32) = (Rng::random(&mut self.rng), Rng::random(&mut self.rng));
-        u1 = u1.clamp(1e-6, 1.0);
-        let z0 = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos(); // ~N(0,1)
-        let mult = 1.0 + z0 * self.noise_std;
+        let noise_mult = 1.0 + gaussian_noise(&mut self.rng, self.noise_std);
+        let kw = self.kw_peak * frac * noise_mult;
 
-        let kw = self.kw_peak * frac * mult;
-        kw.max(0.0)
+        // Return negative for generation (according to power flow convention)
+        -kw.max(0.0)
+    }
+
+    fn device_type(&self) -> &'static str {
+        "SolarPV"
     }
 }
 
@@ -214,10 +223,10 @@ mod tests {
         let mut pv = SolarPv::new(5.0, 24, 6, 18, 0.0, 42);
 
         // No generation during night hours
-        assert_eq!(pv.gen_kw(0), 0.0); // Midnight
-        assert_eq!(pv.gen_kw(5), 0.0); // 5am
-        assert_eq!(pv.gen_kw(18), 0.0); // 6pm
-        assert_eq!(pv.gen_kw(23), 0.0); // 11pm
+        assert_eq!(pv.power_kw(0), 0.0); // Midnight
+        assert_eq!(pv.power_kw(5), 0.0); // 5am
+        assert_eq!(pv.power_kw(18), 0.0); // 6pm
+        assert_eq!(pv.power_kw(23), 0.0); // 11pm
     }
 
     #[test]
@@ -225,7 +234,7 @@ mod tests {
         let mut pv = SolarPv::new(5.0, 24, 6, 18, 0.0, 42);
 
         // With noise_std = 0, noon should generate close to peak
-        let noon_gen = pv.gen_kw(12);
+        let noon_gen = -pv.power_kw(12); // power_kw returns negative for generation
         assert!(noon_gen > 4.9 && noon_gen <= 5.0);
     }
 
@@ -236,7 +245,7 @@ mod tests {
 
         // Same seed should produce identical generation
         for t in 0..24 {
-            assert_eq!(pv1.gen_kw(t), pv2.gen_kw(t));
+            assert_eq!(pv1.power_kw(t), pv2.power_kw(t));
         }
     }
 
@@ -249,7 +258,7 @@ mod tests {
         let mut all_same = true;
         for t in 6..18 {
             // Check only daylight hours
-            if (pv1.gen_kw(t) - pv2.gen_kw(t)).abs() > 1e-5 {
+            if (pv1.power_kw(t) - pv2.power_kw(t)).abs() > 1e-5 {
                 all_same = false;
                 break;
             }
@@ -264,7 +273,7 @@ mod tests {
 
         // Generation should repeat in daily cycles
         for t in 0..24 {
-            assert_eq!(pv.gen_kw(t), pv.gen_kw(t + 24));
+            assert_eq!(pv.power_kw(t), pv.power_kw(t + 24));
         }
     }
 }

--- a/src/devices/types.rs
+++ b/src/devices/types.rs
@@ -1,0 +1,47 @@
+//! Common types and traits for device simulation components.
+
+use rand::{Rng, rngs::StdRng};
+
+/// Trait defining a device that can produce or consume electricity.
+///
+/// This trait provides a common interface for all devices in the simulation,
+/// allowing them to be used interchangeably in power flow calculations.
+pub trait Device {
+    /// Returns the power value at the specified time step.
+    ///
+    /// Positive values indicate power consumption (load),
+    /// negative values indicate power generation.
+    ///
+    /// # Arguments
+    ///
+    /// * `timestep` - The simulation time step
+    ///
+    /// # Returns
+    ///
+    /// Power in kilowatts (kW) at the specified time step
+    fn power_kw(&mut self, timestep: usize) -> f32;
+
+    /// Returns a human-readable type name for the device.
+    fn device_type(&self) -> &'static str;
+}
+
+/// Utility function to generate Gaussian noise using Box-Muller transform.
+///
+/// # Arguments
+///
+/// * `rng` - Random number generator
+/// * `std_dev` - Standard deviation of the noise
+///
+/// # Returns
+///
+/// Random value from a Gaussian distribution with mean 0 and specified standard deviation
+pub fn gaussian_noise(rng: &mut StdRng, std_dev: f32) -> f32 {
+    if std_dev <= 0.0 {
+        return 0.0;
+    }
+
+    let u1: f32 = rng.random::<f32>().clamp(1e-6, 1.0);
+    let u2: f32 = rng.random::<f32>();
+    let z0 = (-2.0 * u1.ln()).sqrt() * (2.0 * std::f32::consts::PI * u2).cos();
+    z0 * std_dev
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
     clock.run(|t| {
         let base_demand_kw = load.power_kw(t);
         let solar_kw = pv.power_kw(t); // Note: power_kw returns negative for generation
-        let net_kw = base_demand_kw - solar_kw;
+        let net_kw = base_demand_kw + solar_kw;
         println!(
             "Timestep {}: {} demand = {:.3} kW, {} generation = {:.3} kW, Net = {:.3} kW",
             t, baseload_device, base_demand_kw, solar_device, solar_kw, net_kw


### PR DESCRIPTION
Create a central Device trait and utility functions for all power components. Standardize power flow conventions (+ for consumption, - for generation) and adds a common interface for all simulation devices.

⚠️ **Note: this isn't technically a pure refactor**
`main.rs` changes it's output logging format marginally. However all of the main `lib` components function identically as expected. 

No associated issue.