### PR TITLE
feat(context): gains DeviceContext struct

### DIFF
--- a/src/devices/baseload.rs
+++ b/src/devices/baseload.rs
@@ -116,6 +116,14 @@ mod tests {
     use super::*;
     use std::f32::consts::PI;
 
+    // Helper function to create a context with just a timestep
+    fn ctx(t: usize) -> DeviceContext {
+        DeviceContext {
+            timestep: t,
+            setpoint_kw: None,
+        }
+    }
+
     #[test]
     fn test_new_baseload() {
         let load = BaseLoad::new(1.0, 0.5, 0.0, 0.1, 24, 42);
@@ -139,34 +147,18 @@ mod tests {
         let mut load = BaseLoad::new(2.0, 1.0, 0.0, 0.0, 4, 42);
 
         // At phase 0, first step should be base_kw (since sin(0) = 0)
-        let context = DeviceContext {
-            timestep: 0,
-            setpoint_kw: None,
-        };
-        assert_eq!(load.power_kw(&context), 2.0);
+        assert_eq!(load.power_kw(&ctx(0)), 2.0);
 
         // At quarter day (π/2), should be base_kw + amp_kw (since sin(π/2) = 1)
-        let context = DeviceContext {
-            timestep: 1,
-            setpoint_kw: None,
-        };
-        let demand = load.power_kw(&context);
+        let demand = load.power_kw(&ctx(1));
         assert!((demand - 3.0).abs() < 1e-5);
 
         // At half day (π), should be base_kw (since sin(π) = 0)
-        let context = DeviceContext {
-            timestep: 2,
-            setpoint_kw: None,
-        };
-        let demand = load.power_kw(&context);
+        let demand = load.power_kw(&ctx(2));
         assert!((demand - 2.0).abs() < 1e-5);
 
         // At 3/4 day (3π/2), should be base_kw - amp_kw (since sin(3π/2) = -1)
-        let context = DeviceContext {
-            timestep: 3,
-            setpoint_kw: None,
-        };
-        let demand = load.power_kw(&context);
+        let demand = load.power_kw(&ctx(3));
         assert!((demand - 1.0).abs() < 1e-5);
     }
 
@@ -176,11 +168,7 @@ mod tests {
         let mut load = BaseLoad::new(2.0, 1.0, PI / 2.0, 0.0, 4, 42);
 
         // At phase π/2, first step should be base_kw + amp_kw (since sin(π/2) = 1)
-        let context = DeviceContext {
-            timestep: 0,
-            setpoint_kw: None,
-        };
-        let demand = load.power_kw(&context);
+        let demand = load.power_kw(&ctx(0));
         assert!((demand - 3.0).abs() < 1e-5);
     }
 
@@ -190,11 +178,7 @@ mod tests {
         let mut load = BaseLoad::new(0.5, 1.0, 0.0, 0.0, 4, 42);
 
         // At 3/4 day (3π/2), base_kw - amp_kw would be negative, but should be clamped to 0
-        let context = DeviceContext {
-            timestep: 3,
-            setpoint_kw: None,
-        };
-        let demand = load.power_kw(&context);
+        let demand = load.power_kw(&ctx(3));
         assert_eq!(demand, 0.0);
     }
 
@@ -205,11 +189,7 @@ mod tests {
         let mut load2 = BaseLoad::new(1.0, 0.0, 0.0, 0.5, 10, 42);
 
         for i in 0..5 {
-            let context = DeviceContext {
-                timestep: i,
-                setpoint_kw: None,
-            };
-            assert_eq!(load1.power_kw(&context), load2.power_kw(&context));
+            assert_eq!(load1.power_kw(&ctx(i)), load2.power_kw(&ctx(i)));
         }
     }
 
@@ -221,11 +201,7 @@ mod tests {
 
         let mut all_same = true;
         for i in 0..5 {
-            let context = DeviceContext {
-                timestep: i,
-                setpoint_kw: None,
-            };
-            if (load1.power_kw(&context) - load2.power_kw(&context)).abs() > 1e-5 {
+            if (load1.power_kw(&ctx(i)) - load2.power_kw(&ctx(i))).abs() > 1e-5 {
                 all_same = false;
                 break;
             }

--- a/src/devices/baseload.rs
+++ b/src/devices/baseload.rs
@@ -1,4 +1,4 @@
-use crate::devices::types::{Device, gaussian_noise};
+use crate::devices::types::{Device, DeviceContext, gaussian_noise};
 use rand::{SeedableRng, rngs::StdRng};
 
 /// A baseload generator that models daily electricity consumption patterns.
@@ -96,8 +96,8 @@ impl Device for BaseLoad {
     /// # Returns
     ///
     /// The power demand in kilowatts at the specified time step
-    fn power_kw(&mut self, timestep: usize) -> f32 {
-        let day_pos = (timestep % self.steps_per_day) as f32 / self.steps_per_day as f32; // [0,1)
+    fn power_kw(&mut self, context: &DeviceContext) -> f32 {
+        let day_pos = (context.timestep % self.steps_per_day) as f32 / self.steps_per_day as f32; // [0,1)
         let angle = 2.0 * std::f32::consts::PI * day_pos + self.phase_rad;
         let sinus = angle.sin();
 
@@ -139,18 +139,34 @@ mod tests {
         let mut load = BaseLoad::new(2.0, 1.0, 0.0, 0.0, 4, 42);
 
         // At phase 0, first step should be base_kw (since sin(0) = 0)
-        assert_eq!(load.power_kw(0), 2.0);
+        let context = DeviceContext {
+            timestep: 0,
+            setpoint_kw: None,
+        };
+        assert_eq!(load.power_kw(&context), 2.0);
 
         // At quarter day (π/2), should be base_kw + amp_kw (since sin(π/2) = 1)
-        let demand = load.power_kw(1);
+        let context = DeviceContext {
+            timestep: 1,
+            setpoint_kw: None,
+        };
+        let demand = load.power_kw(&context);
         assert!((demand - 3.0).abs() < 1e-5);
 
         // At half day (π), should be base_kw (since sin(π) = 0)
-        let demand = load.power_kw(2);
+        let context = DeviceContext {
+            timestep: 2,
+            setpoint_kw: None,
+        };
+        let demand = load.power_kw(&context);
         assert!((demand - 2.0).abs() < 1e-5);
 
         // At 3/4 day (3π/2), should be base_kw - amp_kw (since sin(3π/2) = -1)
-        let demand = load.power_kw(3);
+        let context = DeviceContext {
+            timestep: 3,
+            setpoint_kw: None,
+        };
+        let demand = load.power_kw(&context);
         assert!((demand - 1.0).abs() < 1e-5);
     }
 
@@ -160,7 +176,11 @@ mod tests {
         let mut load = BaseLoad::new(2.0, 1.0, PI / 2.0, 0.0, 4, 42);
 
         // At phase π/2, first step should be base_kw + amp_kw (since sin(π/2) = 1)
-        let demand = load.power_kw(0);
+        let context = DeviceContext {
+            timestep: 0,
+            setpoint_kw: None,
+        };
+        let demand = load.power_kw(&context);
         assert!((demand - 3.0).abs() < 1e-5);
     }
 
@@ -170,7 +190,11 @@ mod tests {
         let mut load = BaseLoad::new(0.5, 1.0, 0.0, 0.0, 4, 42);
 
         // At 3/4 day (3π/2), base_kw - amp_kw would be negative, but should be clamped to 0
-        let demand = load.power_kw(3);
+        let context = DeviceContext {
+            timestep: 3,
+            setpoint_kw: None,
+        };
+        let demand = load.power_kw(&context);
         assert_eq!(demand, 0.0);
     }
 
@@ -181,7 +205,11 @@ mod tests {
         let mut load2 = BaseLoad::new(1.0, 0.0, 0.0, 0.5, 10, 42);
 
         for i in 0..5 {
-            assert_eq!(load1.power_kw(i), load2.power_kw(i));
+            let context = DeviceContext {
+                timestep: i,
+                setpoint_kw: None,
+            };
+            assert_eq!(load1.power_kw(&context), load2.power_kw(&context));
         }
     }
 
@@ -193,7 +221,11 @@ mod tests {
 
         let mut all_same = true;
         for i in 0..5 {
-            if (load1.power_kw(i) - load2.power_kw(i)).abs() > 1e-5 {
+            let context = DeviceContext {
+                timestep: i,
+                setpoint_kw: None,
+            };
+            if (load1.power_kw(&context) - load2.power_kw(&context)).abs() > 1e-5 {
                 all_same = false;
                 break;
             }

--- a/src/devices/mod.rs
+++ b/src/devices/mod.rs
@@ -8,3 +8,4 @@ pub mod types;
 pub use baseload::BaseLoad;
 pub use solar::SolarPv;
 pub use types::Device;
+pub use types::DeviceContext;

--- a/src/devices/types.rs
+++ b/src/devices/types.rs
@@ -2,6 +2,16 @@
 
 use rand::{Rng, rngs::StdRng};
 
+/// Contextual information passed to devices during power calculations.
+/// Includes the current timestep and optional setpoints for controllable devices.
+/// # Fields
+/// * `timestep` - Current simulation timestep
+/// * `setpoint_kw` - Optional power setpoint for controllable devices (kW)
+pub struct DeviceContext {
+    pub timestep: usize,
+    pub setpoint_kw: Option<f32>,
+}
+
 /// Trait defining a device that can produce or consume electricity.
 ///
 /// This trait provides a common interface for all devices in the simulation,
@@ -14,12 +24,14 @@ pub trait Device {
     ///
     /// # Arguments
     ///
-    /// * `timestep` - The simulation time step
+    /// * `context` - Contextual information about the device and simulation state, like:
+    ///  - `timestep`: Current simulation time step
+    ///  - `setpoint_kw`: Optional power setpoint for controllable devices
     ///
     /// # Returns
     ///
     /// Power in kilowatts (kW) at the specified time step
-    fn power_kw(&mut self, timestep: usize) -> f32;
+    fn power_kw(&mut self, context: &DeviceContext) -> f32;
 
     /// Returns a human-readable type name for the device.
     fn device_type(&self) -> &'static str;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 mod devices;
 mod sim;
 
-use devices::{BaseLoad, Device, SolarPv};
+use devices::{BaseLoad, Device, DeviceContext, SolarPv};
 use sim::clock::Clock;
 
 fn main() {
@@ -31,12 +31,22 @@ fn main() {
     let solar_device = pv.device_type();
 
     clock.run(|t| {
-        let base_demand_kw = load.power_kw(t);
-        let solar_kw = pv.power_kw(t); // Note: power_kw returns negative for generation
-        let net_kw = base_demand_kw + solar_kw;
+        let base_context = DeviceContext {
+            timestep: t,
+            setpoint_kw: None,
+        };
+
+        let solar_context = DeviceContext {
+            timestep: t,
+            setpoint_kw: None,
+        };
+
+        let base_demand_kw = load.power_kw(&base_context);
+        let solar_kw = pv.power_kw(&solar_context);
+
         println!(
-            "Timestep {}: {} demand = {:.3} kW, {} generation = {:.3} kW, Net = {:.3} kW",
-            t, baseload_device, base_demand_kw, solar_device, solar_kw, net_kw
+            "Timestep {}: {}={:.2}kW, {}={:.2}kW",
+            t, baseload_device, base_demand_kw, solar_device, solar_kw
         );
         // later: push `kw` into feeder aggregator
     })

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,18 +31,13 @@ fn main() {
     let solar_device = pv.device_type();
 
     clock.run(|t| {
-        let base_context = DeviceContext {
+        let context = DeviceContext {
             timestep: t,
             setpoint_kw: None,
         };
 
-        let solar_context = DeviceContext {
-            timestep: t,
-            setpoint_kw: None,
-        };
-
-        let base_demand_kw = load.power_kw(&base_context);
-        let solar_kw = pv.power_kw(&solar_context);
+        let base_demand_kw = load.power_kw(&context);
+        let solar_kw = pv.power_kw(&context);
 
         println!(
             "Timestep {}: {}={:.2}kW, {}={:.2}kW",


### PR DESCRIPTION
`timestep` information (and as-of-yet unused `setpoint_kw`) are now passed to each method using a DeviceContext struct. This will facilitate devices that require control, e.g. via setpoints or weather patterns.

Pre-requisite for #6
