### PR TITLE
feat(sim): add day-ahead schedule and log target

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use devices::{BaseLoad, Battery, Device, DeviceContext, SolarPv};
 use forecast::NaiveForecast;
 use sim::clock::Clock;
 use sim::feeder::Feeder;
+use sim::schedule::DayAheadSchedule;
 
 fn main() {
     let steps_per_day = 24; // 1-hr intervals
@@ -28,6 +29,7 @@ fn main() {
     }
     let forecaster = NaiveForecast;
     let load_forecast = forecaster.forecast(&baseline, steps_per_day);
+    let target_schedule = DayAheadSchedule::flat_target(&load_forecast);
 
     let mut pv = SolarPv::new(
         5.0,           /* kw_peak */
@@ -58,6 +60,7 @@ fn main() {
 
         let base_demand_kw = load.power_kw(&context);
         let forecast_kw = load_forecast[context.timestep];
+        let target_kw = target_schedule[context.timestep];
         let solar_kw = pv.power_kw(&context);
 
         // Simple battery control strategy:
@@ -79,6 +82,7 @@ fn main() {
         println!(
             "Time (Hr) {t}: {baseload_device}={base_demand_kw:.2} kW, \
             Forecast={forecast_kw:.2} kW, \
+            Target={target_kw:.2} kW, \
             {solar_device}={solar_kw:.2} kW, \
             {battery_device}={battery_kw:.2} kW (SoC={soc:.1}%), \
             {feeder_name}={feeder_kw:.2} kW"

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -1,2 +1,3 @@
 pub mod clock;
 pub mod feeder;
+pub mod schedule;

--- a/src/sim/schedule.rs
+++ b/src/sim/schedule.rs
@@ -1,0 +1,35 @@
+/// Day-ahead schedule generation utilities.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DayAheadSchedule;
+
+impl DayAheadSchedule {
+    /// Generate a flat target schedule equal to the average of the forecast.
+    pub fn flat_target(forecast: &[f32]) -> Vec<f32> {
+        if forecast.is_empty() {
+            return Vec::new();
+        }
+
+        let sum: f32 = forecast.iter().sum();
+        let avg = sum / forecast.len() as f32;
+        vec![avg; forecast.len()]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DayAheadSchedule;
+
+    #[test]
+    fn flat_target_matches_length() {
+        let forecast = vec![1.0, 2.0, 3.0, 4.0];
+        let schedule = DayAheadSchedule::flat_target(&forecast);
+        assert_eq!(schedule.len(), forecast.len());
+    }
+
+    #[test]
+    fn flat_target_is_average() {
+        let forecast = vec![1.0, 2.0, 3.0];
+        let schedule = DayAheadSchedule::flat_target(&forecast);
+        assert_eq!(schedule, vec![2.0, 2.0, 2.0]);
+    }
+}


### PR DESCRIPTION
Introduce `DayAheadSchedule` with a flat target equal to the forecast average. Store the schedule at the simulation timestep resolution and log target kW.

Closes #9 
