### PR TITLE
feat(sim): enforce feeder import/export limits

### DIFF
--- a/src/sim/controller.rs
+++ b/src/sim/controller.rs
@@ -12,6 +12,50 @@ impl NaiveRtController {
     pub fn battery_setpoint_kw(&self, net_without_battery: f32, target_kw: f32) -> f32 {
         net_without_battery - target_kw
     }
+
+    /// Cap a flexible load (e.g., EV charging) so feeder import can be kept under limit
+    /// with available battery discharge.
+    pub fn capped_flexible_load_kw(
+        &self,
+        net_fixed_kw: f32,
+        requested_flexible_kw: f32,
+        max_import_kw: f32,
+        battery_max_discharge_kw: f32,
+    ) -> f32 {
+        let requested = requested_flexible_kw.max(0.0);
+        let overload_kw =
+            (net_fixed_kw + requested - battery_max_discharge_kw - max_import_kw).max(0.0);
+        (requested - overload_kw).max(0.0)
+    }
+
+    /// Compute battery setpoint while enforcing feeder import/export constraints.
+    pub fn constrained_battery_setpoint_kw(
+        &self,
+        net_without_battery_kw: f32,
+        target_kw: f32,
+        max_import_kw: f32,
+        max_export_kw: f32,
+        battery_max_charge_kw: f32,
+        battery_max_discharge_kw: f32,
+    ) -> f32 {
+        let min_feeder_kw = -max_export_kw;
+        let max_feeder_kw = max_import_kw;
+        let constrained_target_kw = target_kw.clamp(min_feeder_kw, max_feeder_kw);
+
+        // From feeder = net_without_battery - battery, derive feasible battery range
+        // that respects feeder limits and battery limits.
+        let low_kw = (-battery_max_charge_kw).max(net_without_battery_kw - max_feeder_kw);
+        let high_kw = battery_max_discharge_kw.min(net_without_battery_kw - min_feeder_kw);
+
+        let desired_kw = net_without_battery_kw - constrained_target_kw;
+        if low_kw <= high_kw {
+            desired_kw.clamp(low_kw, high_kw)
+        } else {
+            // No feasible point can satisfy both battery and feeder limits; return the
+            // battery-limited command closest to desired.
+            desired_kw.clamp(-battery_max_charge_kw, battery_max_discharge_kw)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -30,5 +74,44 @@ mod tests {
         let controller = NaiveRtController;
         let setpoint = controller.battery_setpoint_kw(1.0, 2.5);
         assert_eq!(setpoint, -1.5);
+    }
+
+    #[test]
+    fn caps_flexible_load_when_import_cannot_be_met() {
+        let controller = NaiveRtController;
+        let capped = controller.capped_flexible_load_kw(6.0, 4.0, 5.0, 3.0);
+        assert_eq!(capped, 2.0);
+    }
+
+    #[test]
+    fn keeps_flexible_load_when_import_is_feasible() {
+        let controller = NaiveRtController;
+        let capped = controller.capped_flexible_load_kw(2.0, 2.5, 5.0, 3.0);
+        assert_eq!(capped, 2.5);
+    }
+
+    #[test]
+    fn constrained_battery_setpoint_respects_import_limit() {
+        let controller = NaiveRtController;
+        let battery_kw = controller.constrained_battery_setpoint_kw(6.0, 1.0, 5.0, 4.0, 4.0, 3.0);
+        let feeder_kw = 6.0 - battery_kw;
+        assert!(feeder_kw <= 5.0 + 1e-6);
+    }
+
+    #[test]
+    fn constrained_battery_setpoint_is_battery_limited_when_infeasible() {
+        let controller = NaiveRtController;
+        let battery_kw = controller.constrained_battery_setpoint_kw(10.0, 1.0, 5.0, 4.0, 4.0, 3.0);
+        let feeder_kw = 10.0 - battery_kw;
+        assert_eq!(battery_kw, 3.0);
+        assert_eq!(feeder_kw, 7.0);
+    }
+
+    #[test]
+    fn constrained_battery_setpoint_respects_export_limit() {
+        let controller = NaiveRtController;
+        let battery_kw = controller.constrained_battery_setpoint_kw(-6.0, -5.0, 5.0, 2.0, 4.0, 3.0);
+        let feeder_kw = -6.0 - battery_kw;
+        assert!(feeder_kw >= -2.0 - 1e-6);
     }
 }

--- a/src/sim/feeder.rs
+++ b/src/sim/feeder.rs
@@ -7,11 +7,30 @@
 pub struct Feeder {
     name: &'static str,
     net_kw: f32,
+    max_import_kw: f32,
+    max_export_kw: f32,
 }
 
 impl Feeder {
     pub fn new(name: &'static str) -> Self {
-        Self { name, net_kw: 0.0 }
+        Self {
+            name,
+            net_kw: 0.0,
+            max_import_kw: f32::INFINITY,
+            max_export_kw: f32::INFINITY,
+        }
+    }
+
+    pub fn with_limits(name: &'static str, max_import_kw: f32, max_export_kw: f32) -> Self {
+        assert!(max_import_kw >= 0.0);
+        assert!(max_export_kw >= 0.0);
+
+        Self {
+            name,
+            net_kw: 0.0,
+            max_import_kw,
+            max_export_kw,
+        }
     }
 
     pub fn reset(&mut self) {
@@ -25,6 +44,26 @@ impl Feeder {
 
     pub fn net_kw(&self) -> f32 {
         self.net_kw
+    }
+
+    pub fn max_import_kw(&self) -> f32 {
+        self.max_import_kw
+    }
+
+    pub fn max_export_kw(&self) -> f32 {
+        self.max_export_kw
+    }
+
+    pub fn min_net_kw(&self) -> f32 {
+        -self.max_export_kw
+    }
+
+    pub fn max_net_kw(&self) -> f32 {
+        self.max_import_kw
+    }
+
+    pub fn within_limits(&self) -> bool {
+        self.net_kw >= self.min_net_kw() && self.net_kw <= self.max_net_kw()
     }
 
     pub fn name(&self) -> &'static str {
@@ -41,6 +80,17 @@ mod tests {
         let feeder = Feeder::new("FeederA");
         assert_eq!(feeder.name(), "FeederA");
         assert_eq!(feeder.net_kw(), 0.0);
+        assert_eq!(feeder.max_import_kw(), f32::INFINITY);
+        assert_eq!(feeder.max_export_kw(), f32::INFINITY);
+    }
+
+    #[test]
+    fn test_with_limits() {
+        let feeder = Feeder::with_limits("FeederA", 5.0, 3.0);
+        assert_eq!(feeder.max_import_kw(), 5.0);
+        assert_eq!(feeder.max_export_kw(), 3.0);
+        assert_eq!(feeder.min_net_kw(), -3.0);
+        assert_eq!(feeder.max_net_kw(), 5.0);
     }
 
     #[test]
@@ -58,5 +108,19 @@ mod tests {
         feeder.add_net_kw(2.0);
         feeder.reset();
         assert_eq!(feeder.net_kw(), 0.0);
+    }
+
+    #[test]
+    fn test_within_limits() {
+        let mut feeder = Feeder::with_limits("FeederA", 4.0, 2.0);
+        feeder.add_net_kw(3.5);
+        assert!(feeder.within_limits());
+
+        feeder.add_net_kw(1.0);
+        assert!(!feeder.within_limits());
+
+        feeder.reset();
+        feeder.add_net_kw(-2.5);
+        assert!(!feeder.within_limits());
     }
 }


### PR DESCRIPTION
with controller capping and shedding.

 - add feeder capacity limits (max_import_kw, max_export_kw) and limit checks
  - cap flexible EV charging demand when import limit would be exceeded
  - constrain battery setpoints to respect feeder and battery operating bounds
  - add EV requested-power API so controller can apply pre-dispatch caps
  - integrate constrained dispatch path into main simulation loop and logging
  - add unit tests for feeder limit behavior and constrained controller dispatch

Closes #18 